### PR TITLE
Update runtime.py to use proper SQL query blind values

### DIFF
--- a/runtime.py
+++ b/runtime.py
@@ -1559,7 +1559,7 @@ def sanitize_db(filename):
                 file_path_sanitized = re.sub(r'(\\Users\\+)(?:.*?)(\\+)', r'\1REDACTED\2', file_path, flags=re.IGNORECASE)
             else:
                 file_path_sanitized = re.sub(r'(\/Users\/+)(?:.*?)(\/+)', r'\1REDACTED\2', file_path, flags=re.IGNORECASE)
-            cursor.execute(f"Update BOOT set file_path = '{file_path_sanitized}' where id = {id}")
+            cursor.execute("Update BOOT set file_path = ? where id = ?", (file_path_sanitized, id,))
             con.commit()
     with con:
         data = con.execute("SELECT id, file_path FROM PACKAGE")
@@ -1570,7 +1570,7 @@ def sanitize_db(filename):
                 file_path_sanitized = re.sub(r'(\\Users\\+)(?:.*?)(\\+)', r'\1REDACTED\2', file_path, flags=re.IGNORECASE)
             else:
                 file_path_sanitized = re.sub(r'(\/Users\/+)(?:.*?)(\/+)', r'\1REDACTED\2', file_path, flags=re.IGNORECASE)
-            cursor.execute(f"Update PACKAGE set file_path = '{file_path_sanitized}' where id = {id}")
+            cursor.execute("Update PACKAGE set file_path = ? where id = ?", (file_path_sanitized, id,))
             con.commit()
 
 


### PR DESCRIPTION
Updated two uses of Python format strings for SQL queries to the qmark style recommended by sqlite3 here: https://docs.python.org/3/library/sqlite3.html#sqlite3-placeholders

The code should be tested to ensure no syntactical errors. However, the formatting should help avoid any SQL errors that may have been caused by edge cases with file paths.

There are a few more instances of Python format strings throughout the code. Not a high priority/immediate security issue.