### PR TITLE
Update phone.py for better Linux compatibility

### DIFF
--- a/phone.py
+++ b/phone.py
@@ -2442,7 +2442,7 @@ def get_connected_devices():
             theCmd = f"\"{get_fastboot()}\" devices"
             response = run_shell(theCmd)
             for device in response.stdout.split('\n'):
-                if 'fastboot' in device:
+                if ('fastboot' in device) or ('GenesysLogic' in device):
                     d_id = device.split("\t")
                     d_id = d_id[0].strip()
                     device = Device(d_id, 'f.b')


### PR DESCRIPTION
Adjusted fastboot checks in line 2445 to also accept GenesysLogic as a valid fastboot device. My Pixel Fold on Android 14 shows up as this on Arch Linux and it was breaking flashing functionality. After building with this change I was successfully able to flash the latest system image.