### PR TITLE
Update ubuntu_22_04.yml

### DIFF
--- a/.github/workflows/ubuntu_22_04.yml
+++ b/.github/workflows/ubuntu_22_04.yml
@@ -63,6 +63,8 @@ jobs:
           pip install -U six wheel setuptools
           pip install -U -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04 wxPython
           pip install -r requirements.txt
+          # Remove the line that bundles libreadline
+          sed -i '/bundled_libs.append("libreadline")/d' build.sh          
           python --version && pip freeze
           ./build.sh
           mv dist/PixelFlasher dist/PixelFlasher_Ubuntu_22_04


### PR DESCRIPTION
#109 Remove libreadline from the bundle for Ubuntu22.04 as the latest bundle in Ubuntu is old and not compatible with newer OSes (example Manjaro). This could cause an issue on Ubuntu22.04 