### PR TITLE
Add Magisk Alpha install option & fix module description display

### DIFF
--- a/magisk_downloads.py
+++ b/magisk_downloads.py
@@ -87,7 +87,7 @@ class MagiskDownloads(wx.Dialog):
         for apk in apks:
             if apk.type:
                 index = self.list.InsertItem(i, apk.type)
-                if apk.type in ('stable', 'beta', 'canary', 'debug'):
+                if apk.type in ('stable', 'beta', 'alpha', 'canary', 'debug'):
                     self.list.SetItemColumnImage(i, 0, 0)
                 else:
                     self.list.SetItemColumnImage(i, 0, -1)

--- a/magisk_downloads.py
+++ b/magisk_downloads.py
@@ -87,7 +87,7 @@ class MagiskDownloads(wx.Dialog):
         for apk in apks:
             if apk.type:
                 index = self.list.InsertItem(i, apk.type)
-                if apk.type in ('stable', 'beta', 'alpha', 'canary', 'debug'):
+                if apk.type in ('stable', 'beta', 'canary', 'debug'):
                     self.list.SetItemColumnImage(i, 0, 0)
                 else:
                     self.list.SetItemColumnImage(i, 0, -1)

--- a/phone.py
+++ b/phone.py
@@ -2182,7 +2182,7 @@ add_hosts_module
         if self._magisk_apks is None:
             try:
                 apks = []
-                mlist = ['stable', 'beta', 'alpha', 'canary', 'debug', 'delta canary', 'delta debug', 'special 25203', "special 26401", "special 27001"]
+                mlist = ['stable', 'beta', 'canary', 'debug', 'alpha', 'delta canary', 'delta debug', 'special 25203', "special 26401", "special 27001"]
                 for i in mlist:
                     apk = self.get_magisk_apk_details(i)
                     if apk:

--- a/phone.py
+++ b/phone.py
@@ -2182,7 +2182,7 @@ add_hosts_module
         if self._magisk_apks is None:
             try:
                 apks = []
-                mlist = ['stable', 'beta', 'canary', 'debug', 'delta canary', 'delta debug', 'special 25203', "special 26401", "special 27001"]
+                mlist = ['stable', 'beta', 'alpha', 'canary', 'debug', 'delta canary', 'delta debug', 'special 25203', "special 26401", "special 27001"]
                 for i in mlist:
                     apk = self.get_magisk_apk_details(i)
                     if apk:
@@ -2204,6 +2204,29 @@ add_hosts_module
 
         elif channel == 'beta':
             url = "https://raw.githubusercontent.com/topjohnwu/magisk-files/master/beta.json"
+            
+        elif channel == 'alpha':
+            # Now published at appcenter: https://install.appcenter.ms/users/vvb2060/apps/magisk/distribution_groups/public
+            
+            info_endpoint = "https://install.appcenter.ms/api/v0.1/apps/vvb2060/magisk/distribution_groups/public/public_releases?scope=tester"
+            release_endpoint = "https://install.appcenter.ms/api/v0.1/apps/vvb2060/magisk/distribution_groups/public/releases/{}"
+            
+            res = request_with_fallback(method='GET', url=info_endpoint)
+            
+            latest_id = res.json()[0]['id']
+            
+            res = request_with_fallback(method='GET', url=release_endpoint.format(latest_id))
+            
+            latest_release = res.json()
+            
+            setattr(ma, 'version', latest_release['short_version'])
+            setattr(ma, 'versionCode', latest_release['version'])
+            setattr(ma, 'link', latest_release['download_url'])
+            setattr(ma, 'note_link', "note_link")
+            setattr(ma, 'package', latest_release['bundle_identifier'])
+            setattr(ma, 'release_notes', latest_release['release_notes'])
+            
+            return ma
 
         elif channel == 'canary':
             url = "https://raw.githubusercontent.com/topjohnwu/magisk-files/master/canary.json"
@@ -2312,11 +2335,6 @@ This is a special Magisk build\n\n
             note_link = data['magisk']['note']
             setattr(ma, 'note_link', note_link)
             setattr(ma, 'package', 'com.topjohnwu.magisk')
-            # if channel == 'alpha':
-            #     # Magisk alpha app link is not a full url, build it from url
-            #     setattr(ma, 'link', f"https://github.com/vvb2060/magisk_files/raw/alpha/{ma.link}")
-            #     setattr(ma, 'note_link', "https://raw.githubusercontent.com/vvb2060/magisk_files/alpha/README.md")
-            #     setattr(ma, 'package', 'io.github.vvb2060.magisk')
             if channel in ['delta canary', 'delta debug']:
                 setattr(ma, 'package', 'io.github.huskydg.magisk')
             # Get the note contents

--- a/phone.py
+++ b/phone.py
@@ -2066,7 +2066,7 @@ add_hosts_module
                 if self.mode == 'adb' and self.rooted:
                     if sys.platform == "win32":
                         theCmd = f"\"{get_adb()}\" -s {self.id} shell \"su -c \'for FILE in /data/adb/modules/*; do echo $FILE; if test -f \"$FILE/remove\"; then echo \"state=remove\"; elif test -f \"$FILE/disabled\"; then echo \"state=disabled\"; else echo \"state=enabled\"; fi; cat \"$FILE/module.prop\"; echo; echo -----pf;done\'\""
-                        res = run_shell(theCmd)
+                        res = run_shell(theCmd, encoding='utf-8')
                         if res.returncode == 0:
                             modules = []
                             themodules = res.stdout.split('-----pf\n')

--- a/runtime.py
+++ b/runtime.py
@@ -3266,10 +3266,10 @@ def request_with_fallback(method, url, headers=None, data=None, stream=False):
 # We use this when we want to capture the returncode and also selectively
 # output what we want to console. Nothing is sent to console, both stdout and
 # stderr are only available when the call is completed.
-def run_shell(cmd, timeout=None):
+def run_shell(cmd, timeout=None, encoding='ISO-8859-1'):
     try:
         flush_output()
-        process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='ISO-8859-1', errors="replace", env=get_env_variables())
+        process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding=encoding, errors="replace", env=get_env_variables())
         # Wait for the process to complete or timeout
         stdout, stderr = process.communicate(timeout=timeout)
         # Return the response


### PR DESCRIPTION
Magisk Alpha releases are now officially published at [MS Appcenter ](https://install.appcenter.ms/users/vvb2060/apps/magisk/distribution_groups/public)

This PR adds the option to get it from there to the `Install Magisk` menu

Tested successfully on my phone.

![alpha](https://i.ibb.co/sJgjMqb/image.png)



Second minor fix is that that the magisk module descriptions containing non-ascii characters (like emoji status) are now displayed properly:

![before](https://i.ibb.co/QbWL6dV/image.png) 
-> 
![after](https://i.ibb.co/qDfV9ht/image.png)


To be on the safe side I kept the default encoding of the run_shell function as ISO-8859-1 and simply used utf-8 when parsing module data