### PR TITLE
Use xdg-open instead of assuming Nautilus for Linux

### DIFF
--- a/runtime.py
+++ b/runtime.py
@@ -1316,6 +1316,8 @@ def open_folder(self, path, isFile = False):
         # linux
         elif self.config.linux_file_explorer:
             subprocess.Popen([self.config.linux_file_explorer, dir_path], env=get_env_variables())
+        elif subprocess.call(["which", "xdg-open"], stdout=subprocess.PIPE, stderr=subprocess.PIPE) == 0:
+            subprocess.Popen(["xdg-open", dir_path], env=get_env_variables())  # prefer xdg-open if available
         else:
             subprocess.Popen(["nautilus", dir_path], env=get_env_variables())
     except Exception as e:


### PR DESCRIPTION
Also could instead add a call to set a constant outside of this function to determine the status of `which xdg-open` rather than having this be retested every time `open_folder` is called.