### PR TITLE
Fastboot device detection fix, Linux terminal option settings, logging improvements

### DIFF
--- a/modules.py
+++ b/modules.py
@@ -3169,8 +3169,8 @@ Unless you know what you're doing, it is recommended that you take the default s
         return
 
     # Transfer back patched.img
-    print(f"Pulling {patched_file} from the phone to: {patched_img} ...")
     patched_img_file = os.path.join(tmp_dir_full, patched_img)
+    print(f"Pulling {patched_file} from the phone to: {patched_img_file} ...")
     res = device.pull_file(patched_file, f"\"{patched_img_file}\"")
     if res != 0:
         print("Aborting ...\n")
@@ -3178,7 +3178,7 @@ Unless you know what you're doing, it is recommended that you take the default s
         return
 
     # get the checksum of the *_patched.img
-    print(f"Getting SHA1 of {patched_img_file} ...")
+    print(f"Getting SHA1 of {patched_img} ...")
     checksum = sha1(os.path.join(patched_img_file))
     print(f"SHA1 of {patched_img} file: {checksum}")
 
@@ -3246,7 +3246,7 @@ Unless you know what you're doing, it is recommended that you take the default s
         patched_sha1 = extract_sha1(patched_img_file, 40)
         if patched_sha1:
             print(f"SHA1 embedded in {patched_img_file} is: {patched_sha1}")
-            print(f"Comparing source {boot_file_name} SHA1 with SHA1 embedded in {patched_sha1} (they should match) ...")
+            print(f"Comparing source {boot_file_name} SHA1 with SHA1 embedded in {patched_img} (they should match) ...")
             if patched_sha1 != boot_sha1_long:
                 max_name_length = max(len(patched_img), len(boot_file_name))
                 # Left justify the filenames with spaces

--- a/phone.py
+++ b/phone.py
@@ -4144,10 +4144,10 @@ def update_phones(device_id):
                 device.init('adb')
                 device_details = device.get_device_details()
         if get_fastboot():
-            theCmd = f"\"{get_fastboot()}\" -s {device_id} devices"
+            theCmd = f"\"{get_fastboot()}\" devices"
             debug(theCmd)
             res = run_shell(theCmd)
-            if res and isinstance(res, subprocess.CompletedProcess) and res.returncode == 0 and 'fastboot' in res.stdout:
+            if res and isinstance(res, subprocess.CompletedProcess) and res.returncode == 0 and device_id in res.stdout:
                 debug("device_mode: f.b")
                 device = Device(device_id, 'f.b')
                 device.init('f.b')
@@ -4225,20 +4225,25 @@ def get_connected_devices():
             debug(theCmd)
             res = run_shell(theCmd)
             if res and isinstance(res, subprocess.CompletedProcess) and res.stdout:
+                debug(f"fastboot devices:\n{res.stdout}")
                 for device in res.stdout.split('\n'):
-                    debug(f"fastboot devices:\n{res.stdout}")
                     if 'no permissions' in device:
                         print(f"\n❌ {datetime.now():%Y-%m-%d %H:%M:%S} ERROR: No permissions to access fastboot device\nsee [http://developer.android.com/tools/device.html]")
                         puml("#red:No permissions to access fastboot device;\n", True)
                         continue
-                    if 'fastboot' in device:
+                    try:
                         d_id = device.split("\t")
+                        if len(d_id) != 2:
+                            continue
                         d_id = d_id[0].strip()
                         device = Device(d_id, 'f.b')
                         device.init('f.b')
                         device_details = device.get_device_details()
                         devices.append(device_details)
                         phones.append(device)
+                    except Exception as e:
+                        print(f"\n{datetime.now():%Y-%m-%d %H:%M:%S} ERROR: Encountered an error while getting connected devices.")
+                        traceback.print_exc()
         else:
             print(f"\n❌ {datetime.now():%Y-%m-%d %H:%M:%S} ERROR: fastboot command is not found!")
 

--- a/phone.py
+++ b/phone.py
@@ -3689,7 +3689,7 @@ This is a special Magisk build\n\n
                     debug(theCmd)
                     subprocess.Popen(theCmd, creationflags=subprocess.CREATE_NEW_CONSOLE, start_new_session=True, env=get_env_variables())
                 elif sys.platform.startswith("linux") and config.linux_shell:
-                    theCmd = f"{get_linux_shell()} -- /bin/bash -c {theCmd}"
+                    theCmd = f"{get_linux_shell()} /usr/bin/env bash -c {theCmd}"
                     debug(theCmd)
                     subprocess.Popen(theCmd, start_new_session=True)
                 elif sys.platform.startswith("darwin"):
@@ -3731,7 +3731,7 @@ This is a special Magisk build\n\n
                     res = run_shell3(theCmd, directory=scrcpy_folder, detached=True, creationflags=subprocess.CREATE_NEW_CONSOLE)
                 elif sys.platform.startswith("linux") and config.linux_shell:
                     # subprocess.Popen([get_linux_shell(), "--", "/bin/bash", "-c", theCmd], start_new_session=True)
-                    theCmd = f"{get_linux_shell()} -- /bin/bash -c {theCmd}"
+                    theCmd = f"{get_linux_shell()} /usr/bin/env bash -c {theCmd}"
                     debug(theCmd)
                     res = run_shell3(theCmd, detached=True)
                 elif sys.platform.startswith("darwin"):

--- a/runtime.py
+++ b/runtime.py
@@ -1341,10 +1341,7 @@ def open_terminal(self, path, isFile=False):
             if sys.platform.startswith("win"):
                 subprocess.Popen(["start", "cmd.exe", "/k", "cd", "/d", dir_path], shell=True, env=get_env_variables())
             elif sys.platform.startswith("linux"):
-                if self.config.linux_shell:
-                    subprocess.Popen([self.config.linux_shell, "--working-directory", dir_path], env=get_env_variables())
-                else:
-                    subprocess.Popen(["gnome-terminal", "--working-directory", dir_path], env=get_env_variables())
+                subprocess.Popen(f"{get_linux_shell() or "gnome-terminal --"} '{os.environ.get("SHELL").replace("'", "'\\''")}'", shell=True, cwd=dir_path, env=get_env_variables())
             elif sys.platform.startswith("darwin"):
                 subprocess.Popen(["open", "-a", "Terminal", dir_path], env=get_env_variables())
     except Exception as e:
@@ -4100,7 +4097,7 @@ def run_tool(tool_details):
                 # Dynamic function invocation
                 res = globals()[shell_method](theCmd, directory=directory, detached=detached, creationflags=subprocess.CREATE_NEW_CONSOLE)
         elif sys.platform.startswith("linux") and config.linux_shell:
-            theCmd = f"{get_linux_shell()} -- /bin/bash -c {theCmd}"
+            theCmd = f"{get_linux_shell()} /usr/bin/env bash -c {theCmd}"
             debug(theCmd)
             if shell_method == 'run_shell4':
                 subprocess.Popen(theCmd, start_new_session=detached)


### PR DESCRIPTION
These commits resolve a couple of issues I ran into using PixelFlasher.

The fastboot issue was triggered by plugging in my Pixel on the same USB bus that my laptop fingerprint reader is on.

The shell/terminal changes were made to support using KDE Plasma and NixOS.
KDE konsole uses "-e" and "--workdir" for its options ("-e" has different argument splitting behavior in gnome-terminal).
NixOS doesn't have a global "/bin/bash".

Ideally there would be an error message if "Linux Shell" is not set, but I opted to instead just supply defaults because it will at least log an error. The current behavior for running commands doesn't even provide any notification that there is an issue. Additionally, even if "Linux Shell" is set, it doesn't mean that the default option arguments are correct for the specified shell, and I assume you don't want to force people to manually provide the options when using gnome-terminal.

Thank you for building this!