### PR TITLE
[Critical] Fix Errors on build.sh

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -98,7 +98,7 @@ jobs:
         shell: bash
 
       - name: Install requirements
-        run: PYLZ4_USE_SYSTEM_LZ4="False" ARCHFLAGS="-arch x86_64 -arch arm64" python3.13 -m pip install --no-binary 'bsdiff4,psutil,PyYAML,MarkupSafe,cffi' -r requirements.txt
+        run: PYLZ4_USE_SYSTEM_LZ4="False" ARCHFLAGS="-arch x86_64 -arch arm64" python3.13 -m pip install --no-binary 'bsdiff4,psutil,PyYAML,MarkupSafe,cffi,lz4' -r requirements.txt
 
       - name: List modules and their versions
         run: python3.13 -m pip freeze

--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ DIST_NAME="PixelFlasher"
 pushd "$(dirname "$0")"
 
 if [[ $OSTYPE == 'darwin'* ]]; then
-    if [[$(arch) == 'arm64']]; then
+    if [[ $(arch) == 'arm64' ]]; then
         echo "Building macOS Universal Binary"
         specfile=build-on-mac.spec
     else


### PR DESCRIPTION
I'm very sorry for creating multiple PRs, but there was an error in build.sh while adding legacy builds which made the runner to build arm64-only builds even though they need to build universal builds. I fixed it now.