### PR TITLE
Use correct badge for Linux binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Check the [releases section](https://github.com/badabing2005/PixelFlasher/releas
 
 ### Release Files
 
-[![Windows](https://img.shields.io/badge/-Windows_x64-blue.svg?style=for-the-badge&logo=windows)](https://github.com/badabing2005/PixelFlasher/releases/latest/download/PixelFlasher.exe)[![Linux](https://img.shields.io/badge/-Linux/BSD-red.svg?style=for-the-badge&logo=linux)](https://github.com/badabing2005/PixelFlasher/releases/latest/download/PixelFlasher_Ubuntu_24_04)[![MacOS](https://img.shields.io/badge/-MacOS-black.svg?style=for-the-badge&logo=apple)](https://github.com/badabing2005/PixelFlasher/releases/latest/download/PixelFlasher_macos.dmg)[![Other variants](https://img.shields.io/badge/-Other-grey.svg?style=for-the-badge)](#release-files)[![All versions](https://img.shields.io/badge/-All_Versions-lightgrey.svg?style=for-the-badge)](https://github.com/badabing2005/PixelFlasher/releases)
+[![Windows](https://img.shields.io/badge/-Windows_x64-blue.svg?style=for-the-badge&logo=windows)](https://github.com/badabing2005/PixelFlasher/releases/latest/download/PixelFlasher.exe)[![Linux](https://img.shields.io/badge/-Linux-red.svg?style=for-the-badge&logo=linux)](https://github.com/badabing2005/PixelFlasher/releases/latest/download/PixelFlasher_Ubuntu_24_04)[![MacOS](https://img.shields.io/badge/-MacOS-black.svg?style=for-the-badge&logo=apple)](https://github.com/badabing2005/PixelFlasher/releases/latest/download/PixelFlasher_macos.dmg)[![Other variants](https://img.shields.io/badge/-Other-grey.svg?style=for-the-badge)](#release-files)[![All versions](https://img.shields.io/badge/-All_Versions-lightgrey.svg?style=for-the-badge)](https://github.com/badabing2005/PixelFlasher/releases)
 
 File|Description
 :---|:---


### PR DESCRIPTION
A Linux binary makes no sense on BSD. I'm having doubts even binaries for different BSD distribution will work.