### PR TITLE
Ensure that the menubar is attached before updating/refreshing, fixes #349

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -2158,8 +2158,9 @@ class PixelFlasher(wx.Frame):
         self.Bind(wx.EVT_MENU, self._on_manage_devices, manage_devices_item)
 
         # Force menu bar to refresh
-        self.menuBar.Update()
-        self.menuBar.Refresh()
+        if self.menuBar.IsAttached():
+            self.menuBar.Update()
+            self.menuBar.Refresh()
 
     # -----------------------------------------------
     #                  _on_scan_all_devices


### PR DESCRIPTION
Fixes crash on MacOS, fixes #349

See also https://docs.wxpython.org/wx.MenuBar.html#wx.MenuBar.IsAttached

User would see:
```sh
~ $ /Users/josh/Downloads/PixelFlasher_MacOS_8.15.0.0.app/Contents/MacOS/PixelFlasher ; exit;
config_file_path: /Users/josh/Library/Application Support/PixelFlasher/PixelFlasher.json
WARNING: Failed to load language from PixelFlasher.json: [Errno 2] No such file or directory: '/Users/josh/Library/Application Support/PixelFlasher/PixelFlasher.json', defaulting to English.
INFO: Found locale directory at: /var/folders/wb/lzdb0dhd1nsdvy29s88wl30h0000gn/T/_MEIpSNGaZ/locale
INFO: Changed language to en
INFO: Initializing translation system
INFO: Found locale directory at: /var/folders/wb/lzdb0dhd1nsdvy29s88wl30h0000gn/T/_MEIpSNGaZ/locale
INFO: Available languages: ['it', 'zh_TW', 'zh_CN', 'fr', 'es', 'en']
INFO: Loaded translation for it
INFO: Loaded translation for zh_TW
INFO: Loaded translation for zh_CN
INFO: Loaded translation for fr
INFO: Loaded translation for es
INFO: Loaded translation for en
INFO: Translation system initialized to language: en
INFO: Translation initialization complete
global_args.config: None
config_file_path: /Users/josh/Library/Application Support/PixelFlasher/PixelFlasher.json
Loading configuration File ...
Traceback (most recent call last):
  File "wx/core.py", line 2346, in Notify
  File "wx/core.py", line 3552, in Notify
  File "Main.py", line 7189, in _show_main
  File "Main.py", line 715, in __init__
  File "Main.py", line 1554, in _build_menu_bar
  File "Main.py", line 2162, in _build_devices_menu
wx._core.wxAssertionError: C++ assertion ""IsAttached()"" failed at /private/var/folders/w4/hp1my1ln4216vrmvp2_w45dm0000gn/T/pip-req-build-9go1udnn/ext/wxWidgets/src/osx/menu_osx.cpp(599) in Refresh(): can't refresh unattached menubar
```