### PR TITLE
Add aarch64 (ARM64) Linux support

### DIFF
--- a/build-on-linux.spec
+++ b/build-on-linux.spec
@@ -1,10 +1,18 @@
 # -*- mode: python ; coding: utf-8 -*-
+import os
+import platform
 
 block_cipher = None
 
+# Use 7zzs (static) on x86_64, 7zz (dynamic) on aarch64
+if platform.machine() == 'aarch64':
+    seven_zip_bin = 'bin/7zz'
+else:
+    seven_zip_bin = 'bin/7zzs'
+
 a = Analysis(['PixelFlasher.py'],
              pathex=['.'],
-             binaries=[('bin/7zzs', 'bin')],
+             binaries=[(seven_zip_bin, 'bin')],
              datas=[
                 ("images/icon-64.png", "images"),
                 ("images/icon-dark-64.png", "images"),

--- a/runtime.py
+++ b/runtime.py
@@ -1612,6 +1612,8 @@ def get_path_to_7z() -> str | None:
         path_to_7z =  os.path.join(get_bundle_dir(),'bin', '7zz')
     else:
         path_to_7z =  os.path.join(get_bundle_dir(),'bin', '7zzs')
+        if not os.path.exists(path_to_7z):
+            path_to_7z =  os.path.join(get_bundle_dir(),'bin', '7zz')
 
     if not os.path.exists(path_to_7z):
         print(f"\n❌ {datetime.now():%Y-%m-%d %H:%M:%S} ERROR: {path_to_7z} is not found")


### PR DESCRIPTION
## Summary
- Adds support for building and running PixelFlasher on aarch64 Linux (e.g. Raspberry Pi 5, Debian 13 arm64)
- On aarch64, the static `7zzs` binary is not available, so the build spec now auto-detects the architecture and selects `7zz` (dynamic) on aarch64 or `7zzs` (static) on x86_64
- Runtime `get_path_to_7z()` now falls back from `7zzs` to `7zz` if the static binary is not present

## Test plan
- [x] Built successfully on Raspberry Pi 5 (Debian 13, Python 3.13, aarch64)
- [x] Resulting binary is a working ARM64 ELF executable
- [ ] Verify no regression on x86_64 Linux builds (existing behavior unchanged when `7zzs` is present)