### PR TITLE
Fix macOS crash on launch: revert hookspath that excludes cryptography's Rust binding

### DIFF
--- a/build-on-mac-intel-only.spec
+++ b/build-on-mac-intel-only.spec
@@ -25,7 +25,7 @@ a = Analysis(['PixelFlasher.py'],
                 ('locale', 'locale')
             ],
             hiddenimports=['_cffi_backend'],
-            hookspath=['./pyi-hooks-arm64'],
+            hookspath=[],
             runtime_hooks=[],
             excludes=[
                 'bin/busybox_arm64-v8a',

--- a/build-on-mac.spec
+++ b/build-on-mac.spec
@@ -25,7 +25,7 @@ a = Analysis(['PixelFlasher.py'],
                 ('locale', 'locale')
             ],
             hiddenimports=['_cffi_backend'],
-            hookspath=['./pyi-hooks-arm64'],
+            hookspath=[],
             runtime_hooks=[],
             excludes=[
                 'bin/busybox_arm64-v8a',


### PR DESCRIPTION
## Summary

Since v9.1.3.0, PixelFlasher.app crashes on **every** macOS launch, immediately, before the GUI mainloop starts:

```
ModuleNotFoundError: No module named 'cryptography.hazmat.bindings._rust'
```

This PR reverts the two-character change that caused it. Diff is intentionally minimal: 2 files, 2 lines.

## Root cause

Commit 7f2c252 ("LSPosed database schema has changed again, adapt to it.") bundled two unrelated changes into one commit:

1. An LSPosed SQLite-schema fix in `phone.py` (108 lines, legitimate, unrelated to packaging).
2. A macOS packaging change: `build-on-mac.spec` and `build-on-mac-intel-only.spec` were pointed at the shared `pyi-hooks-arm64/` hooks directory for the first time (`hookspath=['./pyi-hooks-arm64']`), and a new file `pyi-hooks-arm64/hook-cryptography.py` was added to that directory, setting:

   ```python
   excludedimports = ['cryptography.hazmat.bindings._rust']
   ```

`excludedimports` is a real, recognized PyInstaller hook attribute (`PyInstaller.depend.imphook._MAGIC_MODULE_HOOK_ATTRS`, verified against the exact PyInstaller 6.21.0 used by CI) that prunes a module from static dependency analysis, so PyInstaller never copies the compiled `_rust.abi3.so` extension into the frozen `.app`.

The problem: `cryptography`'s pure-Python modules (`x509.certificate_transparency`, `hazmat.primitives.hashes`, `hazmat.backends.openssl.backend`, etc.) still do `from cryptography.hazmat.bindings._rust import ...` **unconditionally at import time**. Modern `cryptography` (this repo pins `>=42.0.5`, CI resolves `49.0.0`) has **no working pure-Python fallback** — even `cryptography.hazmat.backends.openssl.backend`, which sounds like a legacy non-Rust path, itself starts with `from cryptography.hazmat.bindings._rust import openssl as rust_openssl` and instantiates `Backend()` at module-import time. So excluding `_rust` from PyInstaller's graph doesn't skip an optional path — it removes the actual implementation backing nearly the entire package, while the code that unconditionally imports it ships anyway. Result: guaranteed crash, on every Mac, every launch.

The same hook file also defines `get_binaries()` and `get_hidden_imports()` functions, seemingly intended to redirect to `cryptography.hazmat.backends.openssl` as a compensating hidden import. These function names are **not part of PyInstaller's hook API** — only module-level names (`hiddenimports`, `excludedimports`, `binaries`, `datas`, etc.) are read (confirmed against `_MAGIC_MODULE_HOOK_ATTRS`). They're dead code and never execute. Even if they had been wired up correctly, redirecting to `cryptography.hazmat.backends.openssl.backend` would not have helped, per the point above — that module needs `_rust` too.

`pyi-hooks-arm64/` is a **shared** hooks directory that predates this commit and is also used by `build-on-win-arm64.spec` (`hook-wx.py`, for Windows ARM64 wx collection — untouched by this PR, out of scope, not reported broken).

## Ruled out

- **Corrupted/incomplete download.** Reproduced identically across two independent, sha256-verified downloads of the official `PixelFlasher_MacOS.dmg` for v9.1.3.0.
- **The "universal2 guard" allowlist (commit f00a599).** That CI step runs `lipo -archs` against already-installed `site-packages/*.so` files as a pre-flight gate, *before* PyInstaller even starts — it has no code path that affects what PyInstaller bundles. The build log for the actual release build (run 28725407343, job `build_mac`) shows "Universal2 guard passed" as a distinct, earlier step, and the exclusion is explicitly attributed to the hook mechanism: `Suppressing import of 'cryptography.hazmat.bindings._rust' ... due to excluded import ... specified in a hook for ...`. f00a599 silenced a CI signal that *could* have caught this before release; it did not itself cause the runtime crash.
- **A `cryptography` version bump.** `requirements.txt` pins `cryptography>=42.0.5` unchanged across the last known-good tag (v9.1.1.2) and the broken tag (v9.1.3.0).
- **Code signing / notarization stripping the binary.** The file is absent immediately after extracting the official DMG (before any local re-signing), and PyInstaller's own build log shows the exclusion happening during `Analysis`, long before DMG creation or signing.

## Fix

Revert `hookspath` to `[]` in both macOS spec files — exactly the config from the last known-good release, v9.1.1.2. This restores PyInstaller's default (`pyinstaller-hooks-contrib`) `hook-cryptography.py`, the one that correctly collects the binary. `build-on-win-arm64.spec` is untouched.

## Testing (TDD)

Reproduced the failure in an isolated local harness, independent of GitHub's CI logs, pinned to the exact versions CI resolved (`cryptography==49.0.0`, `pyinstaller==6.21.0`, `pyinstaller-hooks-contrib==2026.6`):

- **RED:** built a minimal script (`import cryptography.x509.certificate_transparency`) with the repo's unmodified `hook-cryptography.py` as the only additional hook → `ModuleNotFoundError`, exit 1. Byte-for-byte the same traceback as the real app.
- **GREEN:** same script, same pinned versions, no custom hook (i.e., this PR's fix) → clean import, exit 0.

This isolates the hook as the sufficient cause, independent of universal2/multi-arch build concerns, CI runner quirks, or download integrity.

## Scope note / follow-up

The original motivation for touching this file — "cryptography's Rust extension may be the Non-Universal module in MacOS builds" (f00a599's message) — is a real, separate concern: on the arm64 GitHub Actions runner, pip resolves an arm64-only `cryptography` wheel, which is not itself a universal2 fat binary. That's worth solving properly (e.g. building `cryptography` from source with `ARCHFLAGS="-arch x86_64 -arch arm64"`, the same approach already used for `bsdiff4`/`psutil`/`cffi`/etc. in `mac.yml`), but is out of scope for this PR, which only fixes the unconditional crash. Filed as a follow-up: #361.

